### PR TITLE
Fix syntax errors in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-f [ ! -d "~/.local/share/rhythmbox/plugins/" ]
+if [ ! -d "~/.local/share/rhythmbox/plugins/" ]; then
     mkdir -p ~/.local/share/rhythmbox/plugins/
 fi
 cd ~/.local/share/rhythmbox/plugins/
-f [ ! -d "./chromecast" ]
-    then
+
+if [ ! -d "./chromecast" ]; then
     git clone https://github.com/KeizerDev/Rhythmbox-Chromecast.git chromecast
 fi
+
 cd chromecast/
 git pull origin master
 pip install -r requirements.txt


### PR DESCRIPTION
Trying to run the setup script results in errors. This fixes them.

```
/bin/sh: line 2: f: command not found
/bin/sh: line 4: syntax error near unexpected token `fi'
/bin/sh: line 4: `fi'
```
